### PR TITLE
Added initial service provider controlled binding proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+#Local KCP data files
+.kcp

--- a/service-provider-controlled-binding/aspian/README.md
+++ b/service-provider-controlled-binding/aspian/README.md
@@ -1,0 +1,35 @@
+Access Control for Cross-Workspace API Bindings
+======================
+
+Setup
+---------------
+1. Start KCP. These examples will assume a local instance of KCP with root workspace access
+    * Start from the service-provider-controlled-binding folder as your working directory
+    * Run: `kcp start --token-auth-file=tokens`
+        * The tokens file allows us to log in as different users described in that file
+1. In another terminal, navigate to the root workspace: `kubectl kcp workspace root`
+    * If you have a workspace named 'aspian' in your root, see the note on the next item
+1. Run: `./setup.sh`
+    * Note: This will create a workspace in your root called 'aspian' - if you don't want this (ex: you already have a workspace named aspian that you want to keep), you can update the name of the org workspace on line 1 of setup.sh and 12 of aspian-employees.yaml
+1. Your current workspace should be root:aspian
+
+That created a miniature Aspian organization such that Alex is an employee of Aspian and a member of team observability, and team telemetry exports a Kafka service for which they've created a telemetry-consumers role in their workspace to control who can bind it.
+
+Testing
+-------
+If you now navigate to the observability workspace (`kubectl kcp workspace observability`), you can try to bind the exported Kafka as Alex by running `kubectl apply -f aspian/observability/kafka-binding.yaml --token alex` which should fail with the error: `unable to create APIImport: missing verb='bind' permission on apiexports`
+
+This is because team telemetry hasn't authorized the binding yet1
+
+To authorize the binding, navigate to the telemetry workspace `kubectl kcp workspace root:aspian:telemetry` and apply one of the binding yamls. For example, the following will allow any member of the observability team to bind this API: `kubectl apply -f aspian/telemetry/telemetry-consumers-pergroup.yaml`
+
+To verify this, navigate back to the observability workspace and bind the API as alex:
+```
+kubectl kcp workspace root:aspian:observability
+kubectl apply -f aspian/observability/kafka-binding.yaml --token alex
+```
+..which should succeed.
+
+Further Experimentation
+---------------------------
+The goal of this exercise was to set up a known-good lab based on KCP's documentation which could then serve as a foundation for testing variations on it, including webhook and custom authorizers.

--- a/service-provider-controlled-binding/aspian/aspian-employees.yaml
+++ b/service-provider-controlled-binding/aspian/aspian-employees.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aspian-employee
+  clusterName: root
+rules:
+- apiGroups:
+  - tenancy.kcp.dev
+  resources:
+  - workspaces/content
+  resourceNames:
+  - aspian
+  verbs:
+  - access
+  ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aspian-employees
+  clusterName: root
+subjects:
+- kind: User
+  name: alex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aspian-employee

--- a/service-provider-controlled-binding/aspian/observability-team.yaml
+++ b/service-provider-controlled-binding/aspian/observability-team.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: observability-member
+  clusterName: aspian
+rules:
+- apiGroups:
+  - tenancy.kcp.dev
+  resources:
+  - workspaces/content
+  resourceNames:
+  - observability
+  verbs:
+  - admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: observability-member
+  clusterName: aspian
+subjects:
+- kind: Group
+  name: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: observability-member

--- a/service-provider-controlled-binding/aspian/observability/kafka-binding.yaml
+++ b/service-provider-controlled-binding/aspian/observability/kafka-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: kafka.telemetry
+spec:
+  reference:
+    workspace:
+      path: root:aspian:telemetry
+      exportName: kafka.telemetry
+  acceptedPermissionClaims:
+    - resource: "secrets"
+    - resource: "configmaps"
+    - resource: "namespaces"

--- a/service-provider-controlled-binding/aspian/telemetry/kafka-export.yaml
+++ b/service-provider-controlled-binding/aspian/telemetry/kafka-export.yaml
@@ -1,0 +1,12 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: kafka.telemetry
+spec:
+  permissionClaims:
+    - group: ""
+      resource: "secrets"
+    - group: ""
+      resource: "configmaps"
+    - group: ""
+      resource: "namespaces"

--- a/service-provider-controlled-binding/aspian/telemetry/telemetry-consumers-pergroup.yaml
+++ b/service-provider-controlled-binding/aspian/telemetry/telemetry-consumers-pergroup.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: telemetry-consumers
+  clusterName: telemetry
+subjects:
+- kind: Group
+  name: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: telemetry-consumer

--- a/service-provider-controlled-binding/aspian/telemetry/telemetry-consumers-peruser.yaml
+++ b/service-provider-controlled-binding/aspian/telemetry/telemetry-consumers-peruser.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: telemetry-consumers
+  clusterName: telemetry
+subjects:
+- kind: User
+  name: alex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: telemetry-consumer

--- a/service-provider-controlled-binding/aspian/telemetry/telemetry-consumers.yaml
+++ b/service-provider-controlled-binding/aspian/telemetry/telemetry-consumers.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: telemetry-consumer
+  clusterName: telemetry
+rules:
+- apiGroups:
+  - apis.kcp.dev
+  resources:
+  - apiexports
+  resourceNames:
+  - kafka.telemetry
+  verbs:
+  - bind

--- a/service-provider-controlled-binding/setup.sh
+++ b/service-provider-controlled-binding/setup.sh
@@ -1,0 +1,10 @@
+kubectl kcp workspace create aspian --enter --ignore-existing
+kubectl apply -f aspian/aspian-employees.yaml
+kubectl apply -f aspian/observability-team.yaml
+
+kubectl kcp workspace create telemetry --enter --ignore-existing
+kubectl apply -f aspian/telemetry/kafka-export.yaml
+kubectl apply -f aspian/telemetry/telemetry-consumers.yaml
+
+kubectl kcp workspace ..
+kubectl kcp workspace create observability --ignore-existing

--- a/service-provider-controlled-binding/tokens
+++ b/service-provider-controlled-binding/tokens
@@ -1,0 +1,1 @@
+alex,alex,alex,"observability"


### PR DESCRIPTION
It's mainly a quick way to construct an Aspian org with multiple users but optimized for trying out different ways to authorize API bindings (starting off with RBAC, as documented)